### PR TITLE
Add a rake task to populate topics to kafka

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'scout_apm', '~> 3.0.x'
 
 # Kafka stuff
 gem 'ruby-kafka'
-gem 'avro_turf', github: 'openstax/avro_turf', ref: '6b625753d65488a8b4171df23edc3b16a240af71'
+gem 'avro_turf', github: 'dasch/avro_turf', ref: '6ef7a6b5458a61a9d57307ee0bb1a7fdfb3ed170'
 gem 'avro-builder'
 
 # Versioned API tools

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/dasch/avro_turf.git
+  revision: 6ef7a6b5458a61a9d57307ee0bb1a7fdfb3ed170
+  ref: 6ef7a6b5458a61a9d57307ee0bb1a7fdfb3ed170
+  specs:
+    avro_turf (1.3.0)
+      avro (>= 1.7.7, < 1.11)
+      excon (~> 0.71)
+
+GIT
   remote: https://github.com/openstax/auth-rails.git
   revision: ed2d7da86ca226b93376955b9474c4cf115c611f
   ref: ed2d7da86ca226b93376955b9474c4cf115c611f
@@ -6,15 +15,6 @@ GIT
     openstax_auth (0.1.0)
       activesupport
       json-jwt
-
-GIT
-  remote: https://github.com/openstax/avro_turf.git
-  revision: 6b625753d65488a8b4171df23edc3b16a240af71
-  ref: 6b625753d65488a8b4171df23edc3b16a240af71
-  specs:
-    avro_turf (1.3.0)
-      avro (>= 1.7.7, < 1.11)
-      excon (~> 0.71)
 
 GIT
   remote: https://github.com/openstax/swagger-rails.git

--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ If you want to make a non-breaking change to an event payload, e.g. adding an op
 
 If however you wanted to make a breaking change to a payload, e.g. for the `nudged` event, you'd copy the contents of the `schemas/org/openstax/ec/nudged/v1` directory to a new `schemas/org/openstax/ec/nudged/v2` directory.  Then make your changes in the `v2` directory and run the rake tasks.
 
+#### Registering topics
+
+In order to use kafka (non-locally) you will need to first register your topics with kafka.  To do this, first make
+sure that `config/topics.yml` has the topics you need, then run this rake task to create these within kafka: 
+
+```
+bundle exece rake populate_topics
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md)

--- a/app/services/populate_topics.rb
+++ b/app/services/populate_topics.rb
@@ -1,0 +1,35 @@
+class PopulateTopics
+  def call
+    add_to_kafka(topics_to_add)
+  end
+
+  def topics_to_add
+    ox_topics - kafka_topics
+  end
+
+  def kafka_topics
+    @kafka_topics ||= begin
+      OxKafka.instance.topics
+    end
+  end
+
+  def ox_topics
+    @ox_topics ||= begin
+      topics_from_yml
+    end
+  end
+
+  private
+
+  def add_to_kafka(topics_to_add)
+    topics_to_add.each do |topic|
+      OxKafka.instance.create_topic(topic)
+    end
+  end
+
+  def topics_from_yml
+    topics_path = Rails.root.join('config','topics.yml')
+    topics = YAML.load(File.read(topics_path))
+    topics['topics'].map  {|topic| topic['name'] }
+  end
+end

--- a/app/services/populate_topics.rb
+++ b/app/services/populate_topics.rb
@@ -1,6 +1,7 @@
 class PopulateTopics
   def call
     add_to_kafka(topics_to_add)
+    topics_to_add
   end
 
   def topics_to_add

--- a/config/initializers/kafka.rb
+++ b/config/initializers/kafka.rb
@@ -10,13 +10,20 @@ if Rails.env.development?
   end
 end
 
+class OxKafka
+  def self.instance
+    @@instance ||=
+      begin
+        Kafka.new(Rails.application.secrets.kafka[:broker_host].split(','), logger: Rails.logger)
+      end
+  end
+end
+
 class AsyncKafkaProducer
   def self.instance
     @@instance ||=
       begin
-        kafka = Kafka.new(Rails.application.secrets.kafka[:broker_host].split(','),
-                          logger: Rails.logger)
-        kafka.async_producer(
+        OxKafka.instance.async_producer(
           delivery_interval: Rails.application.secrets.kafka[:delivery_interval],
           delivery_threshold: Rails.application.secrets.kafka[:delivery_threshold]
         )

--- a/config/topics.yml
+++ b/config/topics.yml
@@ -1,0 +1,22 @@
+topics: [
+  {
+    name: 'foo',
+    schemas: [
+        'org.openstax.ec.foo1',
+        'org.openstax.ec.foo2'
+    ],
+    config: {
+      replication: 3
+    }
+  },
+  {
+    name: 'bar',
+    schemas: [
+        'org.openstax.ec.bar1',
+        'org.openstax.ec.bar2'
+    ],
+    config: {
+      replication: 3
+    }
+  }
+]

--- a/config/topics.yml
+++ b/config/topics.yml
@@ -1,22 +1,11 @@
 topics: [
   {
-    name: 'foo',
+    name: 'nudged',
     schemas: [
-        'org.openstax.ec.foo1',
-        'org.openstax.ec.foo2'
+        'org.openstax.ec.nudged_v1'
     ],
     config: {
-      replication: 3
-    }
-  },
-  {
-    name: 'bar',
-    schemas: [
-        'org.openstax.ec.bar1',
-        'org.openstax.ec.bar2'
-    ],
-    config: {
-      replication: 3
+      replication: 1
     }
   }
 ]

--- a/lib/tasks/populate_topics.rake
+++ b/lib/tasks/populate_topics.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'avro/builder'
-
 desc <<-DESC.strip_heredoc
   Add topics defined in config/topics to kafka.
 DESC

--- a/lib/tasks/populate_topics.rake
+++ b/lib/tasks/populate_topics.rake
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'avro/builder'
+
+desc <<-DESC.strip_heredoc
+  Add topics defined in config/topics to kafka, if not present there.
+DESC
+task :populate_topics, [] do
+  PopulateTopics.new.call
+end

--- a/lib/tasks/populate_topics.rake
+++ b/lib/tasks/populate_topics.rake
@@ -3,8 +3,11 @@
 require 'avro/builder'
 
 desc <<-DESC.strip_heredoc
-  Add topics defined in config/topics to kafka, if not present there.
+  Add topics defined in config/topics to kafka.
 DESC
-task :populate_topics, [] do
-  PopulateTopics.new.call
+task populate_topics: :environment do
+  puts "PopulateTopics rake task starting..."
+  topics_added = PopulateTopics.new.call
+  topics_added.each{|topic| puts "\tadded topic ``#{topic}` to kafka`" }
+  puts "PopulateTopics rake task finished: #{topics_added.count} new topics added."
 end

--- a/spec/services/populate_topics_spec.rb
+++ b/spec/services/populate_topics_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PopulateTopics do
+  let(:topics_file_contents) do
+    { 'topics' => [
+      {
+        'name' => 'foo',
+        'schemas' => [
+                'org.openstax.ec.foo1',
+                'org.openstax.ec.foo2'
+              ],
+        'config' => {
+          'replication'=> 3
+        }
+      },
+      {
+        'name' => 'bar',
+        'schemas' => [
+                'org.openstax.ec.bar1',
+                'org.openstax.ec.bar2'
+              ],
+        'config' => {
+          'replication' => 3
+        }
+      } ]
+    }
+  end
+
+  let(:mock_kafka) {
+    double(
+      {
+        topics: ['blue', 'green']
+      }
+    )
+  }
+
+  before do
+    allow(YAML).to receive(:load).and_return(topics_file_contents)
+    allow(OxKafka).to receive(:instance).and_return(mock_kafka)
+  end
+
+  describe '#topics_to_add' do
+    subject(:populate) { PopulateTopics.new }
+
+    it 'calculates the topics needed to be added' do
+      expect(populate.topics_to_add).to eq ['foo', 'bar']
+    end
+  end
+
+  describe '#call' do
+    subject(:populate) { PopulateTopics.new }
+
+    it 'calculates the topics needed to be added' do
+      expect(mock_kafka).to receive(:create_topic).twice
+      expect(populate.call)
+    end
+  end
+end


### PR DESCRIPTION
Create a rake task to seed topics in kafka.  

Ox topics are defined ahead of time in config/topics. 

run the rake task:  `rake populate_topic`