### PR TITLE
Adjust timestamps for device discrepancies

### DIFF
--- a/app/bindings/api/v0/bindings/nudged_v1.rb
+++ b/app/bindings/api/v0/bindings/nudged_v1.rb
@@ -33,10 +33,10 @@ module Api::V0::Bindings
     attr_accessor :medium
 
     # The RFC 3339 section 5.6 date-time when nudge actually occurred.
-    attr_accessor :occurred_at
+    attr_accessor :client_clock_occurred_at
 
     # The RFC 3339 section 5.6 date-time when nudge event was sent to the server.
-    attr_accessor :sent_at
+    attr_accessor :client_clock_sent_at
 
     # The data's type.
     attr_accessor :type
@@ -72,8 +72,8 @@ module Api::V0::Bindings
         :'context' => :'context',
         :'flavor' => :'flavor',
         :'medium' => :'medium',
-        :'occurred_at' => :'occurred_at',
-        :'sent_at' => :'sent_at',
+        :'client_clock_occurred_at' => :'client_clock_occurred_at',
+        :'client_clock_sent_at' => :'client_clock_sent_at',
         :'type' => :'type'
       }
     end
@@ -87,8 +87,8 @@ module Api::V0::Bindings
         :'context' => :'String',
         :'flavor' => :'String',
         :'medium' => :'String',
-        :'occurred_at' => :'DateTime',
-        :'sent_at' => :'DateTime',
+        :'client_clock_occurred_at' => :'DateTime',
+        :'client_clock_sent_at' => :'DateTime',
         :'type' => :'String'
       }
     end
@@ -125,12 +125,12 @@ module Api::V0::Bindings
         self.medium = attributes[:'medium']
       end
 
-      if attributes.has_key?(:'occurred_at')
-        self.occurred_at = attributes[:'occurred_at']
+      if attributes.has_key?(:'client_clock_occurred_at')
+        self.client_clock_occurred_at = attributes[:'client_clock_occurred_at']
       end
 
-      if attributes.has_key?(:'sent_at')
-        self.sent_at = attributes[:'sent_at']
+      if attributes.has_key?(:'client_clock_sent_at')
+        self.client_clock_sent_at = attributes[:'client_clock_sent_at']
       end
 
       if attributes.has_key?(:'type')
@@ -166,14 +166,6 @@ module Api::V0::Bindings
         invalid_properties.push('invalid value for "medium", medium cannot be nil.')
       end
 
-      if @occurred_at.nil?
-        invalid_properties.push('invalid value for "occurred_at", occurred_at cannot be nil.')
-      end
-
-      if @sent_at.nil?
-        invalid_properties.push('invalid value for "sent_at", sent_at cannot be nil.')
-      end
-
       invalid_properties
     end
 
@@ -186,8 +178,6 @@ module Api::V0::Bindings
       return false if @context.nil?
       return false if @flavor.nil?
       return false if @medium.nil?
-      return false if @occurred_at.nil?
-      return false if @sent_at.nil?
       type_validator = EnumAttributeValidator.new('String', ['org.openstax.ec.nudged_v1'])
       return false unless type_validator.valid?(@type)
       true
@@ -214,8 +204,8 @@ module Api::V0::Bindings
           context == o.context &&
           flavor == o.flavor &&
           medium == o.medium &&
-          occurred_at == o.occurred_at &&
-          sent_at == o.sent_at &&
+          client_clock_occurred_at == o.client_clock_occurred_at &&
+          client_clock_sent_at == o.client_clock_sent_at &&
           type == o.type
     end
 
@@ -228,7 +218,7 @@ module Api::V0::Bindings
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [user_uuid, app, target, context, flavor, medium, occurred_at, sent_at, type].hash
+      [user_uuid, app, target, context, flavor, medium, client_clock_occurred_at, client_clock_sent_at, type].hash
     end
 
     # Builds the object from hash

--- a/app/bindings/api/v0/bindings/nudged_v1.rb
+++ b/app/bindings/api/v0/bindings/nudged_v1.rb
@@ -166,6 +166,18 @@ module Api::V0::Bindings
         invalid_properties.push('invalid value for "medium", medium cannot be nil.')
       end
 
+      if @client_clock_occurred_at.nil?
+        invalid_properties.push('invalid value for "client_clock_occurred_at", client_clock_occurred_at cannot be nil.')
+      end
+
+      if @client_clock_sent_at.nil?
+        invalid_properties.push('invalid value for "client_clock_sent_at", client_clock_sent_at cannot be nil.')
+      end
+
+      if @type.nil?
+        invalid_properties.push('invalid value for "type", type cannot be nil.')
+      end
+
       invalid_properties
     end
 
@@ -178,6 +190,9 @@ module Api::V0::Bindings
       return false if @context.nil?
       return false if @flavor.nil?
       return false if @medium.nil?
+      return false if @client_clock_occurred_at.nil?
+      return false if @client_clock_sent_at.nil?
+      return false if @type.nil?
       type_validator = EnumAttributeValidator.new('String', ['org.openstax.ec.nudged_v1'])
       return false unless type_validator.valid?(@type)
       true

--- a/app/bindings/api/v0/bindings/nudged_v1.rb
+++ b/app/bindings/api/v0/bindings/nudged_v1.rb
@@ -32,8 +32,11 @@ module Api::V0::Bindings
     # The nudge medium (e.g., email).
     attr_accessor :medium
 
-    # The unix time (ms since epoc) when nudge occurred.
-    attr_accessor :occurred_at_time_in_browser
+    # The RFC 3339 section 5.6 date-time when nudge actually occurred.
+    attr_accessor :occurred_at
+
+    # The RFC 3339 section 5.6 date-time when nudge event was sent to the server.
+    attr_accessor :sent_at
 
     # The data's type.
     attr_accessor :type
@@ -69,7 +72,8 @@ module Api::V0::Bindings
         :'context' => :'context',
         :'flavor' => :'flavor',
         :'medium' => :'medium',
-        :'occurred_at_time_in_browser' => :'occurred_at_time_in_browser',
+        :'occurred_at' => :'occurred_at',
+        :'sent_at' => :'sent_at',
         :'type' => :'type'
       }
     end
@@ -83,7 +87,8 @@ module Api::V0::Bindings
         :'context' => :'String',
         :'flavor' => :'String',
         :'medium' => :'String',
-        :'occurred_at_time_in_browser' => :'String',
+        :'occurred_at' => :'DateTime',
+        :'sent_at' => :'DateTime',
         :'type' => :'String'
       }
     end
@@ -120,8 +125,12 @@ module Api::V0::Bindings
         self.medium = attributes[:'medium']
       end
 
-      if attributes.has_key?(:'occurred_at_time_in_browser')
-        self.occurred_at_time_in_browser = attributes[:'occurred_at_time_in_browser']
+      if attributes.has_key?(:'occurred_at')
+        self.occurred_at = attributes[:'occurred_at']
+      end
+
+      if attributes.has_key?(:'sent_at')
+        self.sent_at = attributes[:'sent_at']
       end
 
       if attributes.has_key?(:'type')
@@ -157,8 +166,12 @@ module Api::V0::Bindings
         invalid_properties.push('invalid value for "medium", medium cannot be nil.')
       end
 
-      if @occurred_at_time_in_browser.nil?
-        invalid_properties.push('invalid value for "occurred_at_time_in_browser", occurred_at_time_in_browser cannot be nil.')
+      if @occurred_at.nil?
+        invalid_properties.push('invalid value for "occurred_at", occurred_at cannot be nil.')
+      end
+
+      if @sent_at.nil?
+        invalid_properties.push('invalid value for "sent_at", sent_at cannot be nil.')
       end
 
       invalid_properties
@@ -173,7 +186,8 @@ module Api::V0::Bindings
       return false if @context.nil?
       return false if @flavor.nil?
       return false if @medium.nil?
-      return false if @occurred_at_time_in_browser.nil?
+      return false if @occurred_at.nil?
+      return false if @sent_at.nil?
       type_validator = EnumAttributeValidator.new('String', ['org.openstax.ec.nudged_v1'])
       return false unless type_validator.valid?(@type)
       true
@@ -200,7 +214,8 @@ module Api::V0::Bindings
           context == o.context &&
           flavor == o.flavor &&
           medium == o.medium &&
-          occurred_at_time_in_browser == o.occurred_at_time_in_browser &&
+          occurred_at == o.occurred_at &&
+          sent_at == o.sent_at &&
           type == o.type
     end
 
@@ -213,7 +228,7 @@ module Api::V0::Bindings
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [user_uuid, app, target, context, flavor, medium, occurred_at_time_in_browser, type].hash
+      [user_uuid, app, target, context, flavor, medium, occurred_at, sent_at, type].hash
     end
 
     # Builds the object from hash

--- a/app/controllers/api/v0/events_controller.rb
+++ b/app/controllers/api/v0/events_controller.rb
@@ -23,7 +23,7 @@ class Api::V0::EventsController < Api::V0::BaseController
       data[:user_uuid] = CompactUuid.pack(current_user_uuid) if current_user_uuid
 
       # Adjust the client's occurred at time by a device sent at adjustment
-      data[:occurred_at] = TimeUtil.infer_actual_occurred_at_from_client_timestamp(
+      data[:occurred_at] = TimeUtil.infer_actual_occurred_at_from_client_timestamps(
         request_received_at: request.env[:received_at],
         client_clock_occurred_at: api_data[:client_clock_occurred_at],
         client_clock_sent_at: api_data[:client_clock_sent_at]).to_i

--- a/app/controllers/api/v0/events_controller.rb
+++ b/app/controllers/api/v0/events_controller.rb
@@ -18,9 +18,14 @@ class Api::V0::EventsController < Api::V0::BaseController
   private
 
   def patch_data(event_data:)
-    event_data.except(:sent_at).tap do |data|
+    event_data.except(:client_clock_sent_at).tap do |data|
+      # Set the user uuid according to the currently logged in user
       data[:user_uuid] = CompactUuid.pack(current_user_uuid) if current_user_uuid
-      data[:occurred_at] = TimeUtil.apply_offset(normalize_at: event_data[:occurred_at], sent_at: event_data[:sent_at])
+
+      # Adjust the client's occurred at time by a device sent at adjustment
+      data[:occurred_at] = TimeUtil.device_adjust(
+        normalize_at: event_data[:client_clock_occurred_at],
+        sent_at: event_data[:client_clock_sent_at]).to_i
     end
   end
 end

--- a/app/controllers/api/v0/events_controller.rb
+++ b/app/controllers/api/v0/events_controller.rb
@@ -6,12 +6,21 @@ class Api::V0::EventsController < Api::V0::BaseController
     render(json: error, status: error.status_code) and return if error
 
     inbound_binding.events.each do |event|
-      event.data.user_uuid = CompactUuid.pack(current_user_uuid) if current_user_uuid
-      avro_encoded_data = KafkaAvroTurf.instance.encode(event.data.to_hash, schema_name: event.data.type)
+      avro_data = patch_data(event_data: event.data.to_hash)
+      avro_encoded_data = KafkaAvroTurf.instance.encode(avro_data, schema_name: event.data.type)
 
       KafkaClient.async_produce(data: avro_encoded_data, topic: event.topic)
     end
 
     render nothing: true, status: 201
+  end
+
+  private
+
+  def patch_data(event_data:)
+    event_data.except(:sent_at).tap do |data|
+      data[:user_uuid] = CompactUuid.pack(current_user_uuid) if current_user_uuid
+      data[:occurred_at] = TimeUtil.apply_offset(normalize_at: event_data[:occurred_at], sent_at: event_data[:sent_at])
+    end
   end
 end

--- a/app/middlewares/request_received_at.rb
+++ b/app/middlewares/request_received_at.rb
@@ -1,0 +1,10 @@
+class RequestReceivedAt
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    env[:received_at] = Time.now
+    @app.call(env)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ require "action_view/railtie"
 require "action_cable/engine"
 # require "sprockets/railtie"
 # require "rails/test_unit/railtie"
+require_relative '../app/middlewares/request_received_at'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -24,6 +25,8 @@ module EventCaptureApi
 
     config.eager_load_paths << Rails.root.join('lib')
     config.autoload_paths << Rails.root.join("schemas", "org", "openstax")
+
+    config.middleware.insert 0, RequestReceivedAt
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  # for docker support not using "EventedFileUpdateChecker" 
+  # for docker support not using "EventedFileUpdateChecker"
   config.file_watcher = ActiveSupport::FileUpdateChecker
 end

--- a/lib/time_util.rb
+++ b/lib/time_util.rb
@@ -7,9 +7,9 @@ class TimeUtil
   # Return a unix time (ms since epoch)
   #
   # see Designing Data-Intensive Applications by Martin Kleppman, Chapter 11: Stream Processing (p. 471)
-  def self.infer_actual_occurred_at_from_client_timestamp(request_received_at:,
-                                                          client_clock_occurred_at:,
-                                                          client_clock_sent_at:)
+  def self.infer_actual_occurred_at_from_client_timestamps(request_received_at:,
+                                                           client_clock_occurred_at:,
+                                                           client_clock_sent_at:)
     offset_secs = request_received_at - Time.parse(client_clock_sent_at)
     Time.parse(client_clock_occurred_at) + offset_secs
   end

--- a/lib/time_util.rb
+++ b/lib/time_util.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-# Normalize a timestamp to a more accurate time based on an offset of sent time
-# vs now time.
-#
-# see https://images.zenhubusercontent.com/5c75601cce38d251a29ce098/bf41aa5b-c908-4b08-a738-5e940d007170
 class TimeUtil
-  def self.apply_offset(normalize_at:, sent_at:)
-    offset_secs = Time.now.utc - DateTime.parse(sent_at)
-    offset_datetime = DateTime.parse(normalize_at) - offset_secs
-    offset_datetime.strftime('%Q').to_i  #convert to unix time (ms since epoch)
+
+  # Normalize a timestamp to a more accurate time based on an offset of sent time
+  # vs now time.
+  #
+  # Return a unix time (ms since epoch)
+  #
+  # see https://images.zenhubusercontent.com/5c75601cce38d251a29ce098/bf41aa5b-c908-4b08-a738-5e940d007170
+  def self.device_adjust(normalize_at:, sent_at:)
+    offset_secs = Time.now - Time.parse(sent_at)
+    Time.parse(normalize_at) - offset_secs
   end
 end

--- a/lib/time_util.rb
+++ b/lib/time_util.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Normalize a timestamp to a more accurate time based on an offset of sent time
+# vs now time.
+#
+# see https://images.zenhubusercontent.com/5c75601cce38d251a29ce098/bf41aa5b-c908-4b08-a738-5e940d007170
+class TimeUtil
+  def self.apply_offset(normalize_at:, sent_at:)
+    offset_secs = Time.now.utc - DateTime.parse(sent_at)
+    offset_datetime = DateTime.parse(normalize_at) - offset_secs
+    offset_datetime.strftime('%Q').to_i  #convert to unix time (ms since epoch)
+  end
+end

--- a/lib/time_util.rb
+++ b/lib/time_util.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
 
 class TimeUtil
-
   # Normalize a timestamp to a more accurate time based on an offset of sent time
   # vs now time.
   #
   # Return a unix time (ms since epoch)
   #
-  # see https://images.zenhubusercontent.com/5c75601cce38d251a29ce098/bf41aa5b-c908-4b08-a738-5e940d007170
-  def self.device_adjust(normalize_at:, sent_at:)
-    offset_secs = Time.now - Time.parse(sent_at)
-    Time.parse(normalize_at) - offset_secs
+  # see Designing Data-Intensive Applications by Martin Kleppman, Chapter 11: Stream Processing (p. 471)
+  def self.infer_actual_occurred_at_from_client_timestamp(request_received_at:,
+                                                          client_clock_occurred_at:,
+                                                          client_clock_sent_at:)
+    offset_secs = request_received_at - Time.parse(client_clock_sent_at)
+    Time.parse(client_clock_occurred_at) + offset_secs
   end
 end

--- a/schemas/org/openstax/ec/nudged/v1/avro.avsc
+++ b/schemas/org/openstax/ec/nudged/v1/avro.avsc
@@ -33,8 +33,11 @@
       "type": "string"
     },
     {
-      "name": "occurred_at_time_in_browser",
-      "type": "string"
+      "name": "occurred_at",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      }
     }
   ]
 }

--- a/schemas/org/openstax/ec/nudged/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/nudged/v1/avro_builder.rb
@@ -1,6 +1,7 @@
 namespace 'org.openstax.ec'
 
 import 'types/uuid'
+import 'types/date_time'
 
 record :nudged_v1 do
   required :user_uuid, :uuid
@@ -9,5 +10,5 @@ record :nudged_v1 do
   required :context, :string
   required :flavor, :string
   required :medium, :string
-  required :occurred_at_time_in_browser, :string
+  required :occurred_at, :timestamp
 end

--- a/schemas/org/openstax/ec/nudged/v1/swagger.rb
+++ b/schemas/org/openstax/ec/nudged/v1/swagger.rb
@@ -4,7 +4,7 @@ module Ec::Nudged::V1
     include OpenStax::Swagger::SwaggerBlocksExtensions
 
     swagger_schema :NudgedV1 do
-      key :required, [:user_uuid, :app, :target, :context, :flavor, :medium, :occurred_at, :sent_at]
+      key :required, [:user_uuid, :app, :target, :context, :flavor, :medium, :client_clock_occurred_at, :client_clock_sent_at, :type]
       property :user_uuid do
         key :type, :object
         key :format, 'uuid'

--- a/schemas/org/openstax/ec/nudged/v1/swagger.rb
+++ b/schemas/org/openstax/ec/nudged/v1/swagger.rb
@@ -4,7 +4,7 @@ module Ec::Nudged::V1
     include OpenStax::Swagger::SwaggerBlocksExtensions
 
     swagger_schema :NudgedV1 do
-      key :required, [:user_uuid, :app, :target, :context, :flavor, :medium, :occurred_at_time_in_browser]
+      key :required, [:user_uuid, :app, :target, :context, :flavor, :medium, :occurred_at, :sent_at]
       property :user_uuid do
         key :type, :object
         key :format, 'uuid'
@@ -30,9 +30,15 @@ module Ec::Nudged::V1
         key :type, :string
         key :description, 'The nudge medium (e.g., email).'
       end
-      property :occurred_at_time_in_browser do
+      property :occurred_at do
         key :type, :string
-        key :description, 'The unix time (ms since epoc) when nudge occurred.'
+        key :format, 'date-time'
+        key :description, 'The RFC 3339 section 5.6 date-time when nudge actually occurred.'
+      end
+      property :sent_at do
+        key :type, :string
+        key :format, 'date-time'
+        key :description, 'The RFC 3339 section 5.6 date-time when nudge event was sent to the server.'
       end
       property :type do
         key :type, :string

--- a/schemas/org/openstax/ec/nudged/v1/swagger.rb
+++ b/schemas/org/openstax/ec/nudged/v1/swagger.rb
@@ -30,12 +30,12 @@ module Ec::Nudged::V1
         key :type, :string
         key :description, 'The nudge medium (e.g., email).'
       end
-      property :occurred_at do
+      property :client_clock_occurred_at do
         key :type, :string
         key :format, 'date-time'
         key :description, 'The RFC 3339 section 5.6 date-time when nudge actually occurred.'
       end
-      property :sent_at do
+      property :client_clock_sent_at do
         key :type, :string
         key :format, 'date-time'
         key :description, 'The RFC 3339 section 5.6 date-time when nudge event was sent to the server.'

--- a/schemas/org/openstax/ec/types/date_time.rb
+++ b/schemas/org/openstax/ec/types/date_time.rb
@@ -1,0 +1,1 @@
+type_macro :timestamp, long(logical_type: 'timestamp-millis')

--- a/spec/lib/compact_uuid_spec.rb
+++ b/spec/lib/compact_uuid_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'CompactUuid' do
+RSpec.describe CompactUuid do
   let!(:uuid) { SecureRandom.uuid }
 
   describe '.pack' do

--- a/spec/lib/time_util_spec.rb
+++ b/spec/lib/time_util_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TimeUtil do
+  let!(:client_occurred_at) { '2020-10-07T23:30:06+00:00' }
+  let!(:client_sent_at) { '2020-10-07T23:47:06+00:00' }
+  let!(:server_at) { Time.parse('2020-10-07T23:58:06+00:00') }
+
+  before do
+    allow(Time).to receive(:now).and_return(server_at)
+  end
+
+  describe '.device_adjust' do
+    let(:expected_offset_rfc3339) { '2020-10-07T23:19:06+00:00' }
+    let(:expected_offset_unix) { 1602112746 }
+
+    subject(:offset) { described_class.device_adjust(normalize_at: client_occurred_at, sent_at: client_sent_at) }
+
+    it 'correctly offsets the normalized time' do
+      expect(offset.to_i).to eq expected_offset_unix
+      expect(offset.rfc3339).to eq expected_offset_rfc3339
+    end
+  end
+end

--- a/spec/lib/time_util_spec.rb
+++ b/spec/lib/time_util_spec.rb
@@ -3,23 +3,24 @@
 require 'rails_helper'
 
 RSpec.describe TimeUtil do
-  let!(:client_occurred_at) { '2020-10-07T23:30:06+00:00' }
-  let!(:client_sent_at) { '2020-10-07T23:47:06+00:00' }
-  let!(:server_at) { Time.parse('2020-10-07T23:58:06+00:00') }
+  let(:client_occurred_at) { Time.at(42).iso8601 }
+  let(:client_sent_at) { Time.at(45).iso8601 }
+  let(:server_at) { Time.at(38) }
 
   before do
     allow(Time).to receive(:now).and_return(server_at)
   end
 
-  describe '.device_adjust' do
-    let(:expected_offset_rfc3339) { '2020-10-07T23:19:06+00:00' }
-    let(:expected_offset_unix) { 1602112746 }
+  describe '.infer_actual_occurred_at_from_client_timestamps' do
+    subject(:actual_occurred_at_time) {
+      described_class.infer_actual_occurred_at_from_client_timestamp(
+        request_received_at: server_at,
+        client_clock_occurred_at: client_occurred_at,
+        client_clock_sent_at: client_sent_at)
+    }
 
-    subject(:offset) { described_class.device_adjust(normalize_at: client_occurred_at, sent_at: client_sent_at) }
-
-    it 'correctly offsets the normalized time' do
-      expect(offset.to_i).to eq expected_offset_unix
-      expect(offset.rfc3339).to eq expected_offset_rfc3339
+    it 'calculates the actual occurred at time based on client server offset' do
+      expect(actual_occurred_at_time).to eq Time.at(35)
     end
   end
 end

--- a/spec/lib/time_util_spec.rb
+++ b/spec/lib/time_util_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TimeUtil do
 
   describe '.infer_actual_occurred_at_from_client_timestamps' do
     subject(:actual_occurred_at_time) {
-      described_class.infer_actual_occurred_at_from_client_timestamp(
+      described_class.infer_actual_occurred_at_from_client_timestamps(
         request_received_at: server_at,
         client_clock_occurred_at: client_occurred_at,
         client_clock_sent_at: client_sent_at)

--- a/spec/requests/api/v0/events_request_spec.rb
+++ b/spec/requests/api/v0/events_request_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Api::V0::EventsController, type: :request do
         "context": "bookuuid",
         "flavor": "full-screen-v2",
         "medium": "in-app",
-        "occurred_at_time_in_browser": "1599173657",
+        "client_clock_occurred_at": "2020-10-06T18:14:22Z",
+        "client_clock_sent_at": "2020-10-06T18:14:22Z",
         'type': 'org.openstax.ec.nudged_v1',
         'version': '1'
       }
@@ -29,7 +30,8 @@ RSpec.describe Api::V0::EventsController, type: :request do
         "context": "foo uuid",
         "flavor": "full-screen-v2",
         "medium": "in-app",
-        "occurred_at_time_in_browser": "1599173657",
+        "client_clock_occurred_at": "2020-10-06T18:14:22Z",
+        "client_clock_sent_at": "2020-10-06T18:14:22Z",
         'type': 'org.openstax.ec.nudged_v1',
         'version': '1'
       }
@@ -63,7 +65,6 @@ RSpec.describe Api::V0::EventsController, type: :request do
 
     it 'successfully calls the API and sends a data message to kafka' do
       expect(KafkaClient).to receive(:async_produce).twice
-
       post api_v0_events_path, params: attributes
 
       expect(response).to have_http_status(201)


### PR DESCRIPTION
Refactor the timestamps for more accurate "occurred at" time due to device discrepancies.

https://app.zenhub.com/workspaces/quasar-5ef270981e560b0019803111/issues/openstax/quasar/78

```
POST http://localhost:3000/api/v0/events
{
  "events": [
    {
       "data" : {
        "app": "immersion learning",
        "target": "study_guides",
        "context": "bookuuid",
        "flavor": "full-screen-v2",
        "medium": "in-app",
        "client_clock_occurred_at": "2020-10-06T18:14:22Z",
        "client_clock_sent_at": "2020-10-06T18:24:22Z",
        "type": "org.openstax.ec.nudged_v1"
       },
       "topic" : "coolness"
    }
  ]
}
```
