### PR TITLE
Remove the eagerloading of schemas 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,6 @@ module EventCaptureApi
     config.load_defaults 5.2
 
     config.eager_load_paths << Rails.root.join('lib')
-    config.eager_load_paths << Rails.root.join("schemas", "org", "openstax")
     config.autoload_paths << Rails.root.join("schemas", "org", "openstax")
 
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
In production, we dont care about eagerloading of schemas files, just the autoloading.  

Exception: 

```
* Min threads: 5, max threads: 5
* Environment: production
! Unable to load application: LocalJumpError: no block given (yield)
bundler: failed to load command: puma (/home/ubuntu/.rbenv/versions/2.6.6/bin/puma)
LocalJumpError: no block given (yield)
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/task_manager.rb:232:in `in_namespace'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/rake-13.0.1/lib/rake/dsl_definition.rb:141:in `namespace'
  /var/srv/events_api/schemas/org/openstax/ec/nudged/v1/avro_builder.rb:1:in `<main>'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `require'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:23:in `block in require_with_bootsnap_lfi'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/loaded_features_index.rb:92:in `register'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:22:in `require_with_bootsnap_lfi'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/bootsnap-1.4.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:31:in `require'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies.rb:291:in `block in require'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies.rb:257:in `load_dependency'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies.rb:291:in `require'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies.rb:378:in `block in require_or_load'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies.rb:37:in `block in load_interlock'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/dependencies/interlock.rb:14:in `block in loading'
  /home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activesupport-5.2.4.3/lib/active_support/concurrency/share_lock.rb:151:in `exclusive'
```