### PR TITLE
Instantiate kafka singletons in initializer.

### DIFF
--- a/config/initializers/kafka.rb
+++ b/config/initializers/kafka.rb
@@ -48,3 +48,20 @@ class KafkaAvroTurf
       end
   end
 end
+
+# This is important because we are using the puma middleware, which uses both a
+# forking process model and threads to scale.
+
+# There are two concerns:
+# 1) thread safety of the avro_turf gem
+# 2) thread safety of the class singletons
+
+# For #1, the avro_turf gem author states:
+#  "If you eagerly set the instance at application boot time then it's fine –
+#   the async producer is thread safe, so multiple threads can produce using
+#   it. That's in fact one of the main use cases for the async producer."
+
+# For #2, we're defining the class singletons in an initializer, we need to
+# instantiate the singleton here, at rails boot time, before the request cycles.
+AsyncKafkaProducer.instance
+KafkaAvroTurf.instance

--- a/spec/requests/api/v0/events_request_spec.rb
+++ b/spec/requests/api/v0/events_request_spec.rb
@@ -62,6 +62,7 @@ RSpec.describe Api::V0::EventsController, type: :request do
 
     before do
       allow(TopicsConfig).to receive(:get_topic_for_event).and_return('foo_topic')
+      allow(KafkaAvroTurf).to receive(:instance).and_return(double({encode: nil}))
     end
 
     it 'successfully calls the API and sends a data message to kafka' do


### PR DESCRIPTION
This PR addresses several concerns that were brought up with thread safety and the API/Kafka. This is important because we are using the puma middleware, which uses both a forking process model and threads to scale. 

1. thread safety of the avro_turf gem 
2. thread safety of the class singletons

For #1, Dasch (the author of avro_turf gem) said as a reply:

> If you eagerly set the instance at application boot time then it's fine – the async producer is thread safe, so multiple threads can produce using it. That's in fact one of the main use cases for the async producer.

For #2, this PR, we're defining the class singletons in an initializer, but needed to instantiate the singleton, hence the invocation lines added thru this PR. 

https://app.zenhub.com/workspaces/quasar-5ef270981e560b0019803111/issues/openstax/quasar/81