### PR TITLE
Instantiate Kafka clients on puma worker boot

### DIFF
--- a/config/initializers/kafka.rb
+++ b/config/initializers/kafka.rb
@@ -46,29 +46,3 @@ class KafkaAvroTurf
       end
   end
 end
-
-# Initialize external clients after puma forks, but before it spawns threads
-
-# This is important because we are using the puma middleware, which uses both a
-# forking process model and threads to scale.
-
-# There are two concerns:
-# 1) thread safety of the avro_turf gem
-# 2) thread safety of the class singletons
-
-# For #1, the avro_turf gem author states:
-#  "If you eagerly set the instance at application boot time then it's fine –
-#   the async producer is thread safe, so multiple threads can produce using
-#   it. That's in fact one of the main use cases for the async producer."
-
-# For #2, we're defining the class singletons in an initializer, we need to
-# instantiate the singleton here, at rails boot time, before the request cycles.
-on_worker_boot do
-  AsyncKafkaProducer.instance
-
-  KafkaAvroTurf.instance
-end
-
-on_worker_shudown do
-  AsyncKafkaProducer.instance.shutdown
-end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,14 +21,14 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -32,3 +32,29 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+
+# Initialize external clients after puma forks, but before it spawns threads
+
+# This is important because we are using the puma middleware, which uses both a
+# forking process model and threads to scale.
+
+# There are two concerns:
+# 1) thread safety of the avro_turf gem
+# 2) thread safety of the class singletons
+
+# For #1, the avro_turf gem author states:
+#  "If you eagerly set the instance at application boot time then it's fine –
+#   the async producer is thread safe, so multiple threads can produce using
+#   it. That's in fact one of the main use cases for the async producer."
+
+# For #2, we're defining the class singletons in an initializer, we need to
+# instantiate the singleton here, at rails boot time, before the request cycles.
+on_worker_boot do
+  AsyncKafkaProducer.instance
+
+  KafkaAvroTurf.instance
+end
+
+on_worker_shutdown do
+  AsyncKafkaProducer.instance.shutdown
+end


### PR DESCRIPTION
The owner of avro_turf mentioned that the client should be initialized after forking but before threads are spawned, which most closely matches puma's on_worker_boot.

JP made me make a PR...

I also moved the shutdown to on_worker_shutdown so the main puma process doesn't create an instance just to shut it down immediately after.

The deployment has to be updated to ensure the config/puma.rb file it adds also has these lines.