### PR TITLE
add admin uuids to secrets

### DIFF
--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,4 +1,5 @@
 development:
+  admin_uuids: ssm(/external/event-capture/admin_uuids)
   accounts:
     sso:
       cookie_name: 'oxa_dev'
@@ -33,6 +34,7 @@ test:
     schema_url: 'http://localhost:8081/'
     schemas_path: 'schemas'
 production:
+  admin_uuids: ssm(/external/event-capture/admin_uuids)
   accounts:
     sso:
       cookie_name: ssm(sso_cookie_name)


### PR DESCRIPTION
Add the admin_uuids to the secrets.  Fetched from the event-capture aws param store. 