### PR TITLE
Make the admin_uuids code flexible

### DIFF
--- a/app/controllers/api/v0/base_controller.rb
+++ b/app/controllers/api/v0/base_controller.rb
@@ -16,7 +16,7 @@ class Api::V0::BaseController < ApplicationController
     return true if Rails.env.development?
     return false if Rails.application.secrets.admin_uuids.blank?
 
-    allowed_uuids = Rails.application.secrets.admin_uuids.split(',').map(&:strip)
+    allowed_uuids = Rails.application.secrets.admin_uuids.split(',').flatten.map(&:strip)
     allowed_uuids.include?(current_user_uuid)
   end
 

--- a/spec/requests/api/v0/info_request_spec.rb
+++ b/spec/requests/api/v0/info_request_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe 'api v0 info requsts', type: :request, api: :v0 do
           expect(json).to have_key(:data)
         end
 
+        context 'uuids as an array' do
+          let(:admin_uuids) { ["#{user_id}", 'b6200d06-4313-4bf3-b9b3-79720498fa94'] }
+
+          it 'allows authorized user' do
+            stub_current_user_uuid(user_id)
+            api_get '/info'
+            expect(response).to have_http_status(:ok)
+          end
+        end
+
         it 'disallows unauthorized user' do
           stub_current_user_uuid('foobar')
           api_get '/info'


### PR DESCRIPTION
Allow the admin_uuids to come in as a string of comma separated values, or an array of strings, and work the same. 