### PR TITLE
Add device_uuid to avro, refactoring the dsl

### DIFF
--- a/app/controllers/api/v0/events_controller.rb
+++ b/app/controllers/api/v0/events_controller.rb
@@ -22,6 +22,7 @@ class Api::V0::EventsController < Api::V0::BaseController
     api_data.except(:client_clock_sent_at, :client_clock_occurred_at).tap do |data|
       # Set the user uuid according to the currently logged in user
       data[:user_uuid] = CompactUuid.pack(current_user_uuid) if current_user_uuid
+      data[:device_uuid] = CompactUuid.pack(current_device_uuid) if current_device_uuid
 
       # Adjust the client's occurred at time by a device sent at adjustment
       data[:occurred_at] = TimeUtil.infer_actual_occurred_at_from_client_timestamps(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,6 +27,21 @@ class ApplicationController < ActionController::API
   end
 
 
+  def current_device_uuid
+    @current_device_uuid ||= begin
+      if Rails.env.development? && ENV['STUBBED_DEVICE_UUID']
+        ENV['STUBBED_DEVICE_UUID']
+      else
+        if ENV['STUBBED_DEVICE_UUID']
+          Rails.logger.warn("`STUBBED_DEVICE_UUID` environment variable is set but not used in " \
+                            "the #{Rails.env} environment.")
+        end
+
+        request.cookies[Rails.application.secrets.accounts[:device_cookie_name]]
+      end
+    end
+  end
+
   def render_unauthorized_if_no_current_user
     head :unauthorized if current_user_uuid.nil?
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,11 +32,6 @@ class ApplicationController < ActionController::API
       if Rails.env.development? && ENV['STUBBED_DEVICE_UUID']
         ENV['STUBBED_DEVICE_UUID']
       else
-        if ENV['STUBBED_DEVICE_UUID']
-          Rails.logger.warn("`STUBBED_DEVICE_UUID` environment variable is set but not used in " \
-                            "the #{Rails.env} environment.")
-        end
-
         request.cookies[Rails.application.secrets.accounts[:device_cookie_name]]
       end
     end

--- a/config/secrets.yml.example
+++ b/config/secrets.yml.example
@@ -1,6 +1,7 @@
 development:
   admin_uuids: ssm(admin_uuids)
   accounts:
+    device_cookie_name: 'oxdid'
     sso:
       cookie_name: 'oxa_dev'
       signature_public_key: |
@@ -34,6 +35,7 @@ test:
 production:
   admin_uuids: ssm(admin_uuids)
   accounts:
+    device_cookie_name: 'oxdid'
     sso:
       cookie_name: ssm(sso_cookie_name)
       signature_public_key: |

--- a/schemas/org/openstax/ec/accessed_studyguide/v1/avro.avsc
+++ b/schemas/org/openstax/ec/accessed_studyguide/v1/avro.avsc
@@ -17,16 +17,20 @@
       "default": null
     },
     {
+      "name": "user_uuid",
+      "type": [
+        "null",
+        "org.openstax.ec.uuid"
+      ],
+      "default": null
+    },
+    {
       "name": "session_uuid",
       "type": "org.openstax.ec.uuid"
     },
     {
       "name": "session_order",
       "type": "int"
-    },
-    {
-      "name": "user_uuid",
-      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "page_id",

--- a/schemas/org/openstax/ec/accessed_studyguide/v1/avro.avsc
+++ b/schemas/org/openstax/ec/accessed_studyguide/v1/avro.avsc
@@ -4,13 +4,29 @@
   "namespace": "org.openstax.ec",
   "fields": [
     {
+      "name": "device_uuid",
+      "type": [
+        "null",
+        {
+          "name": "uuid",
+          "type": "fixed",
+          "namespace": "org.openstax.ec",
+          "size": 16
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "session_uuid",
+      "type": "org.openstax.ec.uuid"
+    },
+    {
+      "name": "session_order",
+      "type": "int"
+    },
+    {
       "name": "user_uuid",
-      "type": {
-        "name": "uuid",
-        "type": "fixed",
-        "namespace": "org.openstax.ec",
-        "size": 16
-      }
+      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "page_id",
@@ -26,14 +42,6 @@
         "type": "long",
         "logicalType": "timestamp-millis"
       }
-    },
-    {
-      "name": "session_uuid",
-      "type": "org.openstax.ec.uuid"
-    },
-    {
-      "name": "session_order",
-      "type": "int"
     }
   ]
 }

--- a/schemas/org/openstax/ec/accessed_studyguide/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/accessed_studyguide/v1/avro_builder.rb
@@ -2,13 +2,12 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
-import 'types/device'
+import 'types/who_am_i'
 import 'types/ordered_session'
 
 record :accessed_studyguide_v1 do
-  extends :device
+  extends :who_am_i
   extends :ordered_session
-  required :user_uuid, :uuid
   required :page_id, :string
   required :book_id, :string
   required :occurred_at, :timestamp

--- a/schemas/org/openstax/ec/accessed_studyguide/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/accessed_studyguide/v1/avro_builder.rb
@@ -2,12 +2,14 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
+import 'types/device'
+import 'types/ordered_session'
 
 record :accessed_studyguide_v1 do
+  extends :device
+  extends :ordered_session
   required :user_uuid, :uuid
   required :page_id, :string
   required :book_id, :string
   required :occurred_at, :timestamp
-  required :session_uuid, :uuid
-  required :session_order, :int
 end

--- a/schemas/org/openstax/ec/created_highlight/v1/avro.avsc
+++ b/schemas/org/openstax/ec/created_highlight/v1/avro.avsc
@@ -17,16 +17,20 @@
       "default": null
     },
     {
+      "name": "user_uuid",
+      "type": [
+        "null",
+        "org.openstax.ec.uuid"
+      ],
+      "default": null
+    },
+    {
       "name": "session_uuid",
       "type": "org.openstax.ec.uuid"
     },
     {
       "name": "session_order",
       "type": "int"
-    },
-    {
-      "name": "user_uuid",
-      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "highlight_id",

--- a/schemas/org/openstax/ec/created_highlight/v1/avro.avsc
+++ b/schemas/org/openstax/ec/created_highlight/v1/avro.avsc
@@ -4,13 +4,29 @@
   "namespace": "org.openstax.ec",
   "fields": [
     {
+      "name": "device_uuid",
+      "type": [
+        "null",
+        {
+          "name": "uuid",
+          "type": "fixed",
+          "namespace": "org.openstax.ec",
+          "size": 16
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "session_uuid",
+      "type": "org.openstax.ec.uuid"
+    },
+    {
+      "name": "session_order",
+      "type": "int"
+    },
+    {
       "name": "user_uuid",
-      "type": {
-        "name": "uuid",
-        "type": "fixed",
-        "namespace": "org.openstax.ec",
-        "size": 16
-      }
+      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "highlight_id",
@@ -54,14 +70,6 @@
         "type": "long",
         "logicalType": "timestamp-millis"
       }
-    },
-    {
-      "name": "session_uuid",
-      "type": "org.openstax.ec.uuid"
-    },
-    {
-      "name": "session_order",
-      "type": "int"
     }
   ]
 }

--- a/schemas/org/openstax/ec/created_highlight/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/created_highlight/v1/avro_builder.rb
@@ -2,8 +2,12 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
+import 'types/device'
+import 'types/ordered_session'
 
 record :created_highlight_v1 do
+  extends :device
+  extends :ordered_session
   required :user_uuid, :uuid
   required :highlight_id, :string
   required :source_type, :string
@@ -15,6 +19,4 @@ record :created_highlight_v1 do
   required :location_strategies, :string
   required :scope_id, :string
   required :occurred_at, :timestamp
-  required :session_uuid, :uuid
-  required :session_order, :int
 end

--- a/schemas/org/openstax/ec/created_highlight/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/created_highlight/v1/avro_builder.rb
@@ -2,13 +2,12 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
-import 'types/device'
+import 'types/who_am_i'
 import 'types/ordered_session'
 
 record :created_highlight_v1 do
-  extends :device
+  extends :who_am_i
   extends :ordered_session
-  required :user_uuid, :uuid
   required :highlight_id, :string
   required :source_type, :string
   required :source_id, :string

--- a/schemas/org/openstax/ec/nudged/v1/avro.avsc
+++ b/schemas/org/openstax/ec/nudged/v1/avro.avsc
@@ -17,16 +17,20 @@
       "default": null
     },
     {
+      "name": "user_uuid",
+      "type": [
+        "null",
+        "org.openstax.ec.uuid"
+      ],
+      "default": null
+    },
+    {
       "name": "session_uuid",
       "type": "org.openstax.ec.uuid"
     },
     {
       "name": "session_order",
       "type": "int"
-    },
-    {
-      "name": "user_uuid",
-      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "app",

--- a/schemas/org/openstax/ec/nudged/v1/avro.avsc
+++ b/schemas/org/openstax/ec/nudged/v1/avro.avsc
@@ -4,13 +4,29 @@
   "namespace": "org.openstax.ec",
   "fields": [
     {
+      "name": "device_uuid",
+      "type": [
+        "null",
+        {
+          "name": "uuid",
+          "type": "fixed",
+          "namespace": "org.openstax.ec",
+          "size": 16
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "session_uuid",
+      "type": "org.openstax.ec.uuid"
+    },
+    {
+      "name": "session_order",
+      "type": "int"
+    },
+    {
       "name": "user_uuid",
-      "type": {
-        "name": "uuid",
-        "type": "fixed",
-        "namespace": "org.openstax.ec",
-        "size": 16
-      }
+      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "app",
@@ -38,14 +54,6 @@
         "type": "long",
         "logicalType": "timestamp-millis"
       }
-    },
-    {
-      "name": "session_uuid",
-      "type": "org.openstax.ec.uuid"
-    },
-    {
-      "name": "session_order",
-      "type": "int"
     }
   ]
 }

--- a/schemas/org/openstax/ec/nudged/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/nudged/v1/avro_builder.rb
@@ -2,13 +2,12 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
-import 'types/device'
+import 'types/who_am_i'
 import 'types/ordered_session'
 
 record :nudged_v1 do
-  extends :device
+  extends :who_am_i
   extends :ordered_session
-  required :user_uuid, :uuid
   required :app, :string
   required :target, :string
   required :context, :string

--- a/schemas/org/openstax/ec/nudged/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/nudged/v1/avro_builder.rb
@@ -2,8 +2,12 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
+import 'types/device'
+import 'types/ordered_session'
 
 record :nudged_v1 do
+  extends :device
+  extends :ordered_session
   required :user_uuid, :uuid
   required :app, :string
   required :target, :string
@@ -11,6 +15,4 @@ record :nudged_v1 do
   required :flavor, :string
   required :medium, :string
   required :occurred_at, :timestamp
-  required :session_uuid, :uuid
-  required :session_order, :int
 end

--- a/schemas/org/openstax/ec/started_session/v1/avro.avsc
+++ b/schemas/org/openstax/ec/started_session/v1/avro.avsc
@@ -4,13 +4,25 @@
   "namespace": "org.openstax.ec",
   "fields": [
     {
+      "name": "device_uuid",
+      "type": [
+        "null",
+        {
+          "name": "uuid",
+          "type": "fixed",
+          "namespace": "org.openstax.ec",
+          "size": 16
+        }
+      ],
+      "default": null
+    },
+    {
+      "name": "session_uuid",
+      "type": "org.openstax.ec.uuid"
+    },
+    {
       "name": "user_uuid",
-      "type": {
-        "name": "uuid",
-        "type": "fixed",
-        "namespace": "org.openstax.ec",
-        "size": 16
-      }
+      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "ip_address",
@@ -23,10 +35,6 @@
     {
       "name": "user_agent",
       "type": "string"
-    },
-    {
-      "name": "session_uuid",
-      "type": "org.openstax.ec.uuid"
     },
     {
       "name": "occurred_at",

--- a/schemas/org/openstax/ec/started_session/v1/avro.avsc
+++ b/schemas/org/openstax/ec/started_session/v1/avro.avsc
@@ -17,11 +17,15 @@
       "default": null
     },
     {
-      "name": "session_uuid",
-      "type": "org.openstax.ec.uuid"
+      "name": "user_uuid",
+      "type": [
+        "null",
+        "org.openstax.ec.uuid"
+      ],
+      "default": null
     },
     {
-      "name": "user_uuid",
+      "name": "session_uuid",
       "type": "org.openstax.ec.uuid"
     },
     {

--- a/schemas/org/openstax/ec/started_session/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/started_session/v1/avro_builder.rb
@@ -2,13 +2,12 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
-import 'types/device'
+import 'types/who_am_i'
 import 'types/session'
 
 record :started_session_v1 do
-  extends :device
+  extends :who_am_i
   extends :session
-  required :user_uuid, :uuid
   required :ip_address, :string
   required :referrer, :string
   required :user_agent, :string

--- a/schemas/org/openstax/ec/started_session/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/started_session/v1/avro_builder.rb
@@ -2,12 +2,15 @@ namespace 'org.openstax.ec'
 
 import 'types/uuid'
 import 'types/date_time'
+import 'types/device'
+import 'types/session'
 
 record :started_session_v1 do
+  extends :device
+  extends :session
   required :user_uuid, :uuid
   required :ip_address, :string
   required :referrer, :string
   required :user_agent, :string
-  required :session_uuid, :uuid
   required :occurred_at, :timestamp
 end

--- a/schemas/org/openstax/ec/types/device.rb
+++ b/schemas/org/openstax/ec/types/device.rb
@@ -1,0 +1,3 @@
+record :device do
+  optional :device_uuid, :uuid
+end

--- a/schemas/org/openstax/ec/types/device.rb
+++ b/schemas/org/openstax/ec/types/device.rb
@@ -1,3 +1,0 @@
-record :device do
-  optional :device_uuid, :uuid
-end

--- a/schemas/org/openstax/ec/types/ordered_session.rb
+++ b/schemas/org/openstax/ec/types/ordered_session.rb
@@ -1,0 +1,4 @@
+record :ordered_session do
+  required :session_uuid, :uuid
+  required :session_order, :int
+end

--- a/schemas/org/openstax/ec/types/session.rb
+++ b/schemas/org/openstax/ec/types/session.rb
@@ -1,0 +1,3 @@
+record :session do
+  required :session_uuid, :uuid
+end

--- a/schemas/org/openstax/ec/types/who_am_i.rb
+++ b/schemas/org/openstax/ec/types/who_am_i.rb
@@ -1,0 +1,4 @@
+record :who_am_i do
+  optional :device_uuid, :uuid
+  optional :user_uuid, :uuid
+end


### PR DESCRIPTION
Add device_uuid to avro. 

Refactored the avro dsl to make it clearer what are "system" groups of fields vs user defined fields.  

https://app.zenhub.com/workspaces/quasar-5ef270981e560b0019803111/issues/openstax/quasar/89

![image](https://user-images.githubusercontent.com/352161/99596567-670d3f80-29ab-11eb-9c46-f6b19d4b7468.png)
