### PR TITLE
Set the static schema path.

### DIFF
--- a/config/initializers/kafka.rb
+++ b/config/initializers/kafka.rb
@@ -38,7 +38,7 @@ class KafkaAvroTurf
         AvroTurf::Messaging.new(
           namespace: 'org.openstax.ec',
           schema_store: EventCaptureSchemaStore.new(
-            path: Rails.application.secrets.kafka[:schemas_path]
+            path: 'schemas'
           ),
           registry_url: Rails.application.secrets.kafka[:schema_url],
           logger: Rails.logger


### PR DESCRIPTION
Setting the static schema path, needed by the avro_turf gem (it crashes w/out it). 

```
/home/ubuntu/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/bundler/gems/avro_turf-6ef7a6b5458a/lib/avro_turf/schema_store.rb:4:in `initialize': Please specify a schema path (RuntimeError)
```

This was set to static by [this PR](https://github.com/openstax/event-capture-api/pull/33)