### PR TITLE
Remove ip_address and user_agent from the started_session swagger.

### DIFF
--- a/app/bindings/api/v0/bindings/started_session_v1.rb
+++ b/app/bindings/api/v0/bindings/started_session_v1.rb
@@ -23,14 +23,8 @@ module Api::V0::Bindings
     # The data's type.
     attr_accessor :type
 
-    # The session IP address.
-    attr_accessor :ip_address
-
     # The referrer.
     attr_accessor :referrer
-
-    # The user agent.
-    attr_accessor :user_agent
 
     # The client generates this UUID and references it for all future events in this session.
     attr_accessor :session_uuid
@@ -63,9 +57,7 @@ module Api::V0::Bindings
         :'client_clock_occurred_at' => :'client_clock_occurred_at',
         :'client_clock_sent_at' => :'client_clock_sent_at',
         :'type' => :'type',
-        :'ip_address' => :'ip_address',
         :'referrer' => :'referrer',
-        :'user_agent' => :'user_agent',
         :'session_uuid' => :'session_uuid'
       }
     end
@@ -76,9 +68,7 @@ module Api::V0::Bindings
         :'client_clock_occurred_at' => :'DateTime',
         :'client_clock_sent_at' => :'DateTime',
         :'type' => :'String',
-        :'ip_address' => :'String',
         :'referrer' => :'String',
-        :'user_agent' => :'String',
         :'session_uuid' => :'String'
       }
     end
@@ -103,16 +93,8 @@ module Api::V0::Bindings
         self.type = attributes[:'type']
       end
 
-      if attributes.has_key?(:'ip_address')
-        self.ip_address = attributes[:'ip_address']
-      end
-
       if attributes.has_key?(:'referrer')
         self.referrer = attributes[:'referrer']
-      end
-
-      if attributes.has_key?(:'user_agent')
-        self.user_agent = attributes[:'user_agent']
       end
 
       if attributes.has_key?(:'session_uuid')
@@ -136,16 +118,8 @@ module Api::V0::Bindings
         invalid_properties.push('invalid value for "type", type cannot be nil.')
       end
 
-      if @ip_address.nil?
-        invalid_properties.push('invalid value for "ip_address", ip_address cannot be nil.')
-      end
-
       if @referrer.nil?
         invalid_properties.push('invalid value for "referrer", referrer cannot be nil.')
-      end
-
-      if @user_agent.nil?
-        invalid_properties.push('invalid value for "user_agent", user_agent cannot be nil.')
       end
 
       if @session_uuid.nil?
@@ -163,9 +137,7 @@ module Api::V0::Bindings
       return false if @type.nil?
       type_validator = EnumAttributeValidator.new('String', ['org.openstax.ec.started_session_v1'])
       return false unless type_validator.valid?(@type)
-      return false if @ip_address.nil?
       return false if @referrer.nil?
-      return false if @user_agent.nil?
       return false if @session_uuid.nil?
       true
     end
@@ -188,9 +160,7 @@ module Api::V0::Bindings
           client_clock_occurred_at == o.client_clock_occurred_at &&
           client_clock_sent_at == o.client_clock_sent_at &&
           type == o.type &&
-          ip_address == o.ip_address &&
           referrer == o.referrer &&
-          user_agent == o.user_agent &&
           session_uuid == o.session_uuid
     end
 
@@ -203,7 +173,7 @@ module Api::V0::Bindings
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [client_clock_occurred_at, client_clock_sent_at, type, ip_address, referrer, user_agent, session_uuid].hash
+      [client_clock_occurred_at, client_clock_sent_at, type, referrer, session_uuid].hash
     end
 
     # Builds the object from hash

--- a/app/bindings/api/v0/swagger.json
+++ b/app/bindings/api/v0/swagger.json
@@ -377,17 +377,9 @@
             "org.openstax.ec.started_session_v1"
           ]
         },
-        "ip_address": {
-          "type": "string",
-          "description": "The session IP address."
-        },
         "referrer": {
           "type": "string",
           "description": "The referrer."
-        },
-        "user_agent": {
-          "type": "string",
-          "description": "The user agent."
         },
         "session_uuid": {
           "type": "string",
@@ -395,9 +387,8 @@
         }
       },
       "required": [
-        "ip_address",
         "referrer",
-        "user_agent",
+        "session_uuid",
         "client_clock_sent_at",
         "client_clock_occurred_at",
         "type",

--- a/app/controllers/api/v0/events_controller.rb
+++ b/app/controllers/api/v0/events_controller.rb
@@ -20,6 +20,11 @@ class Api::V0::EventsController < Api::V0::BaseController
 
   def convert_api_data_to_kafka_data(api_data:)
     api_data.except(:client_clock_sent_at, :client_clock_occurred_at).tap do |data|
+      if data[:type].include?('org.openstax.ec.started_session')
+        data[:ip_address] = request.remote_ip
+        data[:user_agent] = request.headers['User-Agent']
+      end
+
       # Set the user uuid according to the currently logged in user
       data[:user_uuid] = CompactUuid.pack(current_user_uuid) if current_user_uuid
       data[:device_uuid] = CompactUuid.pack(current_device_uuid) if current_device_uuid

--- a/schemas/org/openstax/ec/started_session/v1/swagger.rb
+++ b/schemas/org/openstax/ec/started_session/v1/swagger.rb
@@ -3,18 +3,10 @@ module Ec::StartedSession::V1
     include SwaggerEventSchema1
 
     swagger_event_schema(:StartedSessionV1, skip_session_fields: true, type: 'org.openstax.ec.started_session_v1') do
-      key :required, [:ip_address, :referrer, :user_agent]
-      property :ip_address do
-        key :type, :string
-        key :description, 'The session IP address.'
-      end
+      key :required, [:referrer, :session_uuid]
       property :referrer do
         key :type, :string
         key :description, 'The referrer.'
-      end
-      property :user_agent do
-        key :type, :string
-        key :description, 'The user agent.'
       end
       property :session_uuid do
         key :type, :string


### PR DESCRIPTION
These 2 fields wont be sent by client, they'll be derived from the request and http headers.

```
POST http://localhost:3000/api/v0/events
{
  "events": [
    {
       "data" : {
        "referrer": "somewhere",
        "client_clock_occurred_at": "2020-10-06T18:14:22Z",
        "client_clock_sent_at": "2020-10-06T18:24:22Z",
        "type": "org.openstax.ec.started_session_v1",
        "session_uuid": "00efb5d8-aa12-4b5f-b15f-ffb7b5395a71",
        "session_order": 1
       }
    }
  ]
}
```


started_session consumer:
```
[ruby-2.6.6@event-capture-api](git:sb/97-remove-ip-address):event-capture-api $ ./docker/compose exec broker  kafka-console-consumer --bootstrap-server localhost:9092 --topic started_session --from-beginning
j?O??PJ׉???>5?'?TI??aʹ?????تK_?_???9Zq127.0.0.1somewherePostmanRuntime/7.26.5ޯ**??
```



https://app.zenhub.com/workspaces/quasar-5ef270981e560b0019803111/issues/openstax/quasar/97