### PR TITLE
Better events validation / better names and docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :test do
   # Code Climate integration
   # gem "codeclimate-test-reporter", require: false
 
-  gem 'codecov', require: false
+  gem 'codecov', '~> 0.2.13', require: false
   gem 'simplecov', require: false
   gem 'sinatra'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,18 +97,15 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
-    codecov (0.2.1)
-      colorize
-      json
-      simplecov
+    codecov (0.2.13)
+      simplecov (~> 0.18.0)
     coderay (1.1.3)
-    colorize (0.8.1)
     concurrent-ruby (1.1.6)
     crack (0.4.4)
     crass (1.0.6)
     diff-lcs (1.4.3)
     digest-crc (0.5.1)
-    docile (1.3.2)
+    docile (1.3.3)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -124,7 +121,6 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
-    json (2.3.1)
     json-jwt (1.13.0)
       activesupport (>= 4.2)
       aes_key_wrap
@@ -254,7 +250,7 @@ GEM
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
-    simplecov-html (0.12.2)
+    simplecov-html (0.12.3)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -300,7 +296,7 @@ DEPENDENCIES
   aws-sdk-ssm
   bootsnap (>= 1.1.0)
   byebug
-  codecov
+  codecov (~> 0.2.13)
   dotenv-rails
   listen (>= 3.0.5, < 3.2)
   lograge

--- a/app/bindings/api/v0/bindings/event.rb
+++ b/app/bindings/api/v0/bindings/event.rb
@@ -14,7 +14,7 @@ require 'date'
 
 module Api::V0::Bindings
   class Event
-    # The event payload object.  Will be of a type that lives in a swagger file inside the schemas directory.
+    # The event object.  Will be of a type that lives in a swagger file inside the schemas directory.
     attr_accessor :data
 
     # Attribute mapping from ruby-style variable name to JSON key.
@@ -48,12 +48,17 @@ module Api::V0::Bindings
     # @return Array for valid properties with the reasons
     def list_invalid_properties
       invalid_properties = Array.new
+      if @data.nil?
+        invalid_properties.push('invalid value for "data", data cannot be nil.')
+      end
+
       invalid_properties
     end
 
     # Check to see if the all the properties in the model are valid
     # @return true if the model is valid
     def valid?
+      return false if @data.nil?
       true
     end
 

--- a/app/bindings/api/v0/bindings/events.rb
+++ b/app/bindings/api/v0/bindings/events.rb
@@ -14,7 +14,7 @@ require 'date'
 
 module Api::V0::Bindings
   class Events
-    # Array of Events
+    # Array of Event
     attr_accessor :events
 
     # Attribute mapping from ruby-style variable name to JSON key.

--- a/app/bindings/api/v0/swagger.json
+++ b/app/bindings/api/v0/swagger.json
@@ -30,7 +30,7 @@
       "post": {
         "summary": "Captures events",
         "description": "Capture one or more events",
-        "operationId": "addEvent",
+        "operationId": "addEvents",
         "produces": [
           "application/json"
         ],
@@ -39,7 +39,7 @@
         ],
         "parameters": [
           {
-            "name": "events",
+            "name": "payload",
             "in": "body",
             "required": true,
             "schema": {
@@ -48,8 +48,8 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Success."
+          "201": {
+            "description": "Created."
           }
         }
       }
@@ -99,10 +99,13 @@
       }
     },
     "Event": {
+      "required": [
+        "data"
+      ],
       "properties": {
         "data": {
           "type": "object",
-          "description": "The event payload object.  Will be of a type that lives in a swagger file inside the schemas directory."
+          "description": "The event object.  Will be of a type that lives in a swagger file inside the schemas directory."
         }
       }
     },
@@ -110,7 +113,7 @@
       "properties": {
         "events": {
           "type": "array",
-          "description": "Array of Events",
+          "description": "Array of Event",
           "items": {
             "$ref": "#/definitions/Event"
           }

--- a/app/controllers/api/v0/events_swagger.rb
+++ b/app/controllers/api/v0/events_swagger.rb
@@ -3,16 +3,17 @@ class Api::V0::EventsSwagger
   include OpenStax::Swagger::SwaggerBlocksExtensions
 
   swagger_schema :Event do
+    key :required, [:data]
     property :data do
       key :type, :object
-      key :description, 'The event payload object.  Will be of a type that lives in a swagger file inside the schemas directory.'
+      key :description, 'The event object.  Will be of a type that lives in a swagger file inside the schemas directory.'
     end
   end
 
   swagger_schema :Events do
     property :events do
       key :type, :array
-      key :description, 'Array of Events'
+      key :description, 'Array of Event'
       items do
         key :'$ref', :Event
       end
@@ -23,7 +24,7 @@ class Api::V0::EventsSwagger
     operation :post do
       key :summary, 'Captures events'
       key :description, 'Capture one or more events'
-      key :operationId, 'addEvent'
+      key :operationId, 'addEvents'
       key :produces, [
         'application/json'
       ]
@@ -31,15 +32,15 @@ class Api::V0::EventsSwagger
         'Events'
       ]
       parameter do
-        key :name, :events
+        key :name, :payload # ignored but used in various ways in client generation
         key :in, :body
         key :required, true
         schema do
           key :'$ref', :Events
         end
       end
-      response 200 do
-        key :description, 'Success.'
+      response 201 do
+        key :description, 'Created.'
       end
       # extend Api::V0::SwaggerResponses::AuthenticationError
       # extend Api::V0::SwaggerResponses::UnprocessableEntityError

--- a/lib/v0_bindings_extensions.rb
+++ b/lib/v0_bindings_extensions.rb
@@ -6,7 +6,7 @@ Rails.application.config.to_prepare do
 
   # If we're running the task to generate model bindings, there's nothing yet
   # to monkey patch, so bail.
-  next if RakeUtils.running_task?(/generate_model_bindings/)
+  next if RakeUtils.running_task?(/generate_model_bindings|generate_swagger/)
 
   Api::V0::Bindings::Events.class_exec do
     alias_method :original_valid?, :valid?
@@ -16,7 +16,7 @@ Rails.application.config.to_prepare do
 
     alias_method :original_list_invalid_properties, :list_invalid_properties
     def list_invalid_properties
-      event_invalid_properties = events.map_with_index do |event,ii|
+      event_invalid_properties = events.map.with_index do |event,ii|
         event.list_invalid_properties.map do |message|
           "Event [#{ii}]: #{message}"
         end

--- a/lib/v0_bindings_extensions.rb
+++ b/lib/v0_bindings_extensions.rb
@@ -16,9 +16,9 @@ Rails.application.config.to_prepare do
 
     alias_method :original_list_invalid_properties, :list_invalid_properties
     def list_invalid_properties
-      event_invalid_properties = events.map.with_index do |event,ii|
+      event_invalid_properties = events.map.with_index do |event,index|
         event.list_invalid_properties.map do |message|
-          "Event [#{ii}]: #{message}"
+          "Event [#{index}]: #{message}"
         end
       end.flatten
 

--- a/spec/requests/api/v0/events_request_spec.rb
+++ b/spec/requests/api/v0/events_request_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Api::V0::EventsController, type: :request do
         "client_clock_sent_at": "2020-10-06T18:14:22Z",
         'type': 'org.openstax.ec.nudged_v1',
         'version': '1',
-        'session_uuid': 'ed3cdd93-6688-4fcb-b5b3-da3e71052454'
+        'session_uuid': 'ed3cdd93-6688-4fcb-b5b3-da3e71052454',
+        'session_order': 42
       }
     }
 
@@ -35,6 +36,7 @@ RSpec.describe Api::V0::EventsController, type: :request do
         "client_clock_sent_at": "2020-10-06T18:14:22Z",
         'type': 'org.openstax.ec.nudged_v1',
         'session_uuid': 'ed3cdd93-6688-4fcb-b5b3-da3e71052454',
+        'session_order': 42,
         'version': '1'
       }
     }
@@ -84,11 +86,24 @@ RSpec.describe Api::V0::EventsController, type: :request do
       expect(response).to have_http_status(201)
     end
 
+    it 'gives a 422 with error messages for any invalid event and sends none to Kafka' do
+      expect(KafkaClient).not_to receive(:async_produce)
+
+      data1.delete(:session_uuid)
+      post api_v0_events_path, params: attributes
+
+      expect(response).to have_http_status(422)
+      expect(JSON.parse(response.body)["messages"]).to include(
+        /Event \[0\]: invalid value for "session_uuid/
+      )
+    end
+
     context 'when the request is a started_session' do
       let(:data) do
         {
           'type': 'org.openstax.ec.started_session_v1',
           'session_uuid': 'ed3cdd93-6688-4fcb-b5b3-da3e71052454',
+          'referrer': 'https://google.com',
           'client_clock_occurred_at': '2020-10-06T18:14:22Z',
           'client_clock_sent_at': '2020-10-06T18:14:22Z',
         }

--- a/spec/requests/api/v0/events_request_spec.rb
+++ b/spec/requests/api/v0/events_request_spec.rb
@@ -133,6 +133,18 @@ RSpec.describe Api::V0::EventsController, type: :request do
 
         post api_v0_events_path, params: event_attributes, headers: headers
       end
+
+      it 'sends occurred_at to kafka' do
+        expect(avro_turf).to receive(:encode).with(hash_including(occurred_at: kind_of(Integer)), anything)
+        post api_v0_events_path, params: event_attributes, headers: headers
+      end
+
+      it 'does not send the other timestamps to kafka' do
+        expect(avro_turf).to receive(:encode).with(hash_not_including(
+          client_clock_sent_at: anything, client_clock_occurred_at: anything
+        ), anything)
+        post api_v0_events_path, params: event_attributes, headers: headers
+      end
     end
 
     context 'when a logged-in user submits an event' do


### PR DESCRIPTION
* Previously specific event validation was not happening.
* Changes the name of the /events POST body to `payload`
* Returns error messages for events in the body.
* Adds tests