### PR TITLE
Remove anonymous uuid sentinel values, fix misc bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ coverage/*
 
 .DS_Store
 
+.irb-history
+
 clients/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,8 @@ require 'openstax/auth/strategy_2'
 class ApplicationController < ActionController::API
   include RescueFromUnlessLocal
 
-  # will delete this as soon as we have anonymous users
-  # we'll always have user ids
-  TEMP_ANONYMOUS = '7c56ebf5-a850-44b1-a5e5-8e3866f6a248'
+  # Sentinel value so we'll always have user and device ids
+  ANONYMOUS_UUID = '00000000-0000-0000-0000-000000000000'
 
   def current_user_uuid
     @current_user_uuid ||= begin
@@ -21,7 +20,7 @@ class ApplicationController < ActionController::API
                             "the #{Rails.env} environment.")
         end
 
-        OpenStax::Auth::Strategy2.user_uuid(request) || TEMP_ANONYMOUS
+        OpenStax::Auth::Strategy2.user_uuid(request) || ANONYMOUS_UUID
       end
     end
   end
@@ -32,12 +31,9 @@ class ApplicationController < ActionController::API
       if Rails.env.development? && ENV['STUBBED_DEVICE_UUID']
         ENV['STUBBED_DEVICE_UUID']
       else
-        request.cookies[Rails.application.secrets.accounts[:device_cookie_name]]
+        request.cookies[Rails.application.secrets.accounts[:device_cookie_name]] || ANONYMOUS_UUID
       end
     end
   end
 
-  def render_unauthorized_if_no_current_user
-    head :unauthorized if current_user_uuid.nil?
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,6 @@ require 'openstax/auth/strategy_2'
 class ApplicationController < ActionController::API
   include RescueFromUnlessLocal
 
-  # Sentinel value so we'll always have user and device ids
-  ANONYMOUS_UUID = '00000000-0000-0000-0000-000000000000'
-
   def current_user_uuid
     @current_user_uuid ||= begin
       if Rails.application.load_testing? && request.headers['HTTP_LOADTEST_CLIENT_UUID']
@@ -20,7 +17,7 @@ class ApplicationController < ActionController::API
                             "the #{Rails.env} environment.")
         end
 
-        OpenStax::Auth::Strategy2.user_uuid(request) || ANONYMOUS_UUID
+        OpenStax::Auth::Strategy2.user_uuid(request) || nil
       end
     end
   end
@@ -31,7 +28,7 @@ class ApplicationController < ActionController::API
       if Rails.env.development? && ENV['STUBBED_DEVICE_UUID']
         ENV['STUBBED_DEVICE_UUID']
       else
-        request.cookies[Rails.application.secrets.accounts[:device_cookie_name]] || ANONYMOUS_UUID
+        request.cookies[Rails.application.secrets.accounts[:device_cookie_name]] || nil
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::API
                             "the #{Rails.env} environment.")
         end
 
-        OpenStax::Auth::Strategy2.user_uuid(request) || nil
+        OpenStax::Auth::Strategy2.user_uuid(request)
       end
     end
   end
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::API
       if Rails.env.development? && ENV['STUBBED_DEVICE_UUID']
         ENV['STUBBED_DEVICE_UUID']
       else
-        request.cookies[Rails.application.secrets.accounts[:device_cookie_name]] || nil
+        request.cookies[Rails.application.secrets.accounts[:device_cookie_name]]
       end
     end
   end

--- a/lib/time_util.rb
+++ b/lib/time_util.rb
@@ -10,7 +10,11 @@ class TimeUtil
   def self.infer_actual_occurred_at_from_client_timestamps(request_received_at:,
                                                            client_clock_occurred_at:,
                                                            client_clock_sent_at:)
-    offset_secs = request_received_at - Time.parse(client_clock_sent_at)
-    Time.parse(client_clock_occurred_at) + offset_secs
+    offset_secs = request_received_at - parse(client_clock_sent_at)
+    parse(client_clock_occurred_at) + offset_secs
+  end
+
+  def self.parse(datetime_or_string)
+    datetime_or_string.is_a?(String) ? Time.parse(datetime_or_string) : datetime_or_string
   end
 end

--- a/lib/v0_bindings_extensions.rb
+++ b/lib/v0_bindings_extensions.rb
@@ -40,7 +40,7 @@ Rails.application.config.to_prepare do
     def data=(data_object)
       *_, record_name = data_object[:type].split('.')
       swagger_class = swagger_class_for_record_name(record_name)
-      @data = swagger_class.new(data_object)
+      @data = swagger_class.new.build_from_hash(data_object)
     end
 
     def swagger_class_for_record_name(record_name)

--- a/schemas/org/openstax/ec/accessed_studyguide/v1/avro.avsc
+++ b/schemas/org/openstax/ec/accessed_studyguide/v1/avro.avsc
@@ -46,13 +46,17 @@
     },
     {
       "name": "query",
-      "type": {
-        "type": "map",
-        "values": {
-          "type": "array",
-          "items": "string"
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
         }
-      }
+      ],
+      "default": null
     },
     {
       "name": "page_id",

--- a/schemas/org/openstax/ec/created_highlight/v1/avro.avsc
+++ b/schemas/org/openstax/ec/created_highlight/v1/avro.avsc
@@ -46,13 +46,17 @@
     },
     {
       "name": "query",
-      "type": {
-        "type": "map",
-        "values": {
-          "type": "array",
-          "items": "string"
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
         }
-      }
+      ],
+      "default": null
     },
     {
       "name": "highlight_id",

--- a/schemas/org/openstax/ec/nudged/v1/avro.avsc
+++ b/schemas/org/openstax/ec/nudged/v1/avro.avsc
@@ -46,13 +46,17 @@
     },
     {
       "name": "query",
-      "type": {
-        "type": "map",
-        "values": {
-          "type": "array",
-          "items": "string"
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
         }
-      }
+      ],
+      "default": null
     },
     {
       "name": "app",

--- a/schemas/org/openstax/ec/started_session/v1/avro.avsc
+++ b/schemas/org/openstax/ec/started_session/v1/avro.avsc
@@ -42,13 +42,17 @@
     },
     {
       "name": "query",
-      "type": {
-        "type": "map",
-        "values": {
-          "type": "array",
-          "items": "string"
+      "type": [
+        "null",
+        {
+          "type": "map",
+          "values": {
+            "type": "array",
+            "items": "string"
+          }
         }
-      }
+      ],
+      "default": null
     },
     {
       "name": "ip_address",

--- a/schemas/org/openstax/ec/types/source_uri.rb
+++ b/schemas/org/openstax/ec/types/source_uri.rb
@@ -2,5 +2,5 @@ record :source_uri do
   required :scheme, :string
   required :host, :string
   required :path, :string
-  required :query, :map, values: array(:string)
+  optional :query, :map, values: array(:string)
 end

--- a/spec/requests/api/v0/events_request_spec.rb
+++ b/spec/requests/api/v0/events_request_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe Api::V0::EventsController, type: :request do
       {
         'events': [
           {
-            'data': data1 ,
+            'data': data1,
           }
         ]
       }
@@ -139,19 +139,16 @@ RSpec.describe Api::V0::EventsController, type: :request do
     let(:agent) { 'agent' }
     let(:ip_address) { '1.1.1.1' }
 
-    let(:avro_turf) {
-      double({encode: nil})
-    }
+    let(:avro_turf) { KafkaAvroTurf.instance }
 
     before do
       allow(TopicsConfig).to receive(:get_topic_for_event).and_return('foo_topic')
-      allow(KafkaAvroTurf).to receive(:instance).and_return(avro_turf)
     end
 
     it 'successfully calls the API and sends a data message to kafka' do
       expect(KafkaClient).to receive(:async_produce).twice
-      expect(avro_turf).to receive(:encode).
-        with(hash_excluding( user_agent: agent, ip_address: ip_address), anything)
+      expect(avro_turf).to receive(:encode).twice
+        .with(hash_excluding( user_agent: agent, ip_address: ip_address), anything)
 
       post api_v0_events_path, params: attributes
 

--- a/spec/requests/api/v0/kafka_data_spec.rb
+++ b/spec/requests/api/v0/kafka_data_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Api::V0::EventsController::KafkaData do
   # mock controller and request
   let(:remote_ip) { '192.168.1.1' }
   let(:user_id) { 'd8388680-80cf-4fdb-95bb-829a46342115' }
+  let(:device_id) { '9c2e4a92-67ef-11eb-847e-a71a7356faee' }
   let(:received_at) { Time.parse('2020-10-06T18:14:27Z') }
 
   let(:fake_controller) do
@@ -19,7 +20,8 @@ RSpec.describe Api::V0::EventsController::KafkaData do
           'User-Agent' => 'My Crazy Test Browser'
         )
       ),
-      current_user_uuid: user_id
+      current_user_uuid: user_id,
+      current_device_uuid: device_id
     )
   end
 
@@ -89,6 +91,12 @@ RSpec.describe Api::V0::EventsController::KafkaData do
   it 'compacts  the user_id' do
     expect(instance).to include(
       user_uuid: CompactUuid.pack(user_id)
+    )
+  end
+
+  it 'compacts  the device_id' do
+    expect(instance).to include(
+      device_uuid: CompactUuid.pack(device_id)
     )
   end
 

--- a/spec/requests/api/v0/kafka_data_spec.rb
+++ b/spec/requests/api/v0/kafka_data_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'rails_helper'
 require 'ostruct'
 
 RSpec.describe Api::V0::EventsController::KafkaData do
@@ -100,7 +101,15 @@ RSpec.describe Api::V0::EventsController::KafkaData do
     )
   end
 
-  it 'includes the event type' do
-    expect(instance).to include(type: 'org.openstax.ec.started_session')
+  it 'includes the event schema name' do
+    expect(instance.schema_name).to include('org.openstax.ec.started_session')
+  end
+
+  it 'returns nil for unknown key' do
+    expect(instance[:foo]).to be_nil
+  end
+
+  it 'works with string keys' do
+    expect(instance["referrer"]).to be_a String
   end
 end


### PR DESCRIPTION
* Remove anonymous uuid sentinel value, for both user and device ids.
* Fix bug where `KafkaData` was returning its initializer arguments when an unknown key was requested
* Make the source URI's query field optional in Kafka.
* Fix bug where Avro conversion was looking up data using string keys in a hash with symbol keys.
* Fix the yanked mimemagic gem problem plaguing all-the-apps.
* Turned on Kafka schema validation... I think this will give us better error messages to the client, but if someone is concerned about performance of that we should talk.