### PR TITLE
add additional session fields

### DIFF
--- a/app/bindings/api/v0/bindings/started_session_v1.rb
+++ b/app/bindings/api/v0/bindings/started_session_v1.rb
@@ -32,6 +32,12 @@ module Api::V0::Bindings
     # The client generates this UUID and references it for all future events in this session.
     attr_accessor :session_uuid
 
+    # The code version of the app.
+    attr_accessor :release_id
+
+    # The service worker state
+    attr_accessor :service_worker
+
     class EnumAttributeValidator
       attr_reader :datatype
       attr_reader :allowable_values
@@ -62,7 +68,9 @@ module Api::V0::Bindings
         :'type' => :'type',
         :'source_uri' => :'source_uri',
         :'referrer' => :'referrer',
-        :'session_uuid' => :'session_uuid'
+        :'session_uuid' => :'session_uuid',
+        :'release_id' => :'release_id',
+        :'service_worker' => :'service_worker'
       }
     end
 
@@ -74,7 +82,9 @@ module Api::V0::Bindings
         :'type' => :'String',
         :'source_uri' => :'String',
         :'referrer' => :'String',
-        :'session_uuid' => :'String'
+        :'session_uuid' => :'String',
+        :'release_id' => :'String',
+        :'service_worker' => :'String'
       }
     end
 
@@ -108,6 +118,14 @@ module Api::V0::Bindings
 
       if attributes.has_key?(:'session_uuid')
         self.session_uuid = attributes[:'session_uuid']
+      end
+
+      if attributes.has_key?(:'release_id')
+        self.release_id = attributes[:'release_id']
+      end
+
+      if attributes.has_key?(:'service_worker')
+        self.service_worker = attributes[:'service_worker']
       end
     end
 
@@ -153,6 +171,8 @@ module Api::V0::Bindings
       return false if @source_uri.nil?
       return false if @referrer.nil?
       return false if @session_uuid.nil?
+      service_worker_validator = EnumAttributeValidator.new('String', ['unsupported', 'inactive', 'active'])
+      return false unless service_worker_validator.valid?(@service_worker)
       true
     end
 
@@ -166,6 +186,16 @@ module Api::V0::Bindings
       @type = type
     end
 
+    # Custom attribute writer method checking allowed values (enum).
+    # @param [Object] service_worker Object to be assigned
+    def service_worker=(service_worker)
+      validator = EnumAttributeValidator.new('String', ['unsupported', 'inactive', 'active'])
+      unless validator.valid?(service_worker)
+        fail ArgumentError, 'invalid value for "service_worker", must be one of #{validator.allowable_values}.'
+      end
+      @service_worker = service_worker
+    end
+
     # Checks equality by comparing each attribute.
     # @param [Object] Object to be compared
     def ==(o)
@@ -176,7 +206,9 @@ module Api::V0::Bindings
           type == o.type &&
           source_uri == o.source_uri &&
           referrer == o.referrer &&
-          session_uuid == o.session_uuid
+          session_uuid == o.session_uuid &&
+          release_id == o.release_id &&
+          service_worker == o.service_worker
     end
 
     # @see the `==` method
@@ -188,7 +220,7 @@ module Api::V0::Bindings
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [client_clock_occurred_at, client_clock_sent_at, type, source_uri, referrer, session_uuid].hash
+      [client_clock_occurred_at, client_clock_sent_at, type, source_uri, referrer, session_uuid, release_id, service_worker].hash
     end
 
     # Builds the object from hash

--- a/app/bindings/api/v0/swagger.json
+++ b/app/bindings/api/v0/swagger.json
@@ -170,6 +170,62 @@
         }
       }
     },
+    "StartedSessionV1": {
+      "properties": {
+        "client_clock_occurred_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The RFC 3339 section 5.6 date-time when event actually occurred."
+        },
+        "client_clock_sent_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The RFC 3339 section 5.6 date-time when event was sent to the server."
+        },
+        "type": {
+          "type": "string",
+          "description": "The data's type.",
+          "enum": [
+            "org.openstax.ec.started_session_v1"
+          ]
+        },
+        "source_uri": {
+          "type": "string",
+          "description": "client location when event occurred."
+        },
+        "referrer": {
+          "type": "string",
+          "description": "The referrer."
+        },
+        "session_uuid": {
+          "type": "string",
+          "description": "The client generates this UUID and references it for all future events in this session."
+        },
+        "release_id": {
+          "type": "string",
+          "description": "The code version of the app."
+        },
+        "service_worker": {
+          "type": "string",
+          "description": "The service worker state",
+          "enum": [
+            "unsupported",
+            "inactive",
+            "active"
+          ]
+        }
+      },
+      "required": [
+        "referrer",
+        "session_uuid",
+        "client_clock_sent_at",
+        "client_clock_occurred_at",
+        "type",
+        "source_uri",
+        "session_uuid",
+        "session_order"
+      ]
+    },
     "NudgedV1": {
       "properties": {
         "client_clock_occurred_at": {
@@ -229,49 +285,6 @@
         "context",
         "flavor",
         "medium",
-        "client_clock_sent_at",
-        "client_clock_occurred_at",
-        "type",
-        "source_uri",
-        "session_uuid",
-        "session_order"
-      ]
-    },
-    "StartedSessionV1": {
-      "properties": {
-        "client_clock_occurred_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The RFC 3339 section 5.6 date-time when event actually occurred."
-        },
-        "client_clock_sent_at": {
-          "type": "string",
-          "format": "date-time",
-          "description": "The RFC 3339 section 5.6 date-time when event was sent to the server."
-        },
-        "type": {
-          "type": "string",
-          "description": "The data's type.",
-          "enum": [
-            "org.openstax.ec.started_session_v1"
-          ]
-        },
-        "source_uri": {
-          "type": "string",
-          "description": "client location when event occurred."
-        },
-        "referrer": {
-          "type": "string",
-          "description": "The referrer."
-        },
-        "session_uuid": {
-          "type": "string",
-          "description": "The client generates this UUID and references it for all future events in this session."
-        }
-      },
-      "required": [
-        "referrer",
-        "session_uuid",
         "client_clock_sent_at",
         "client_clock_occurred_at",
         "type",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-from ruby:2.6.6
+from ruby:2.6.8
 
 ### rails
 

--- a/schemas/org/openstax/ec/started_session/v1/avro.avsc
+++ b/schemas/org/openstax/ec/started_session/v1/avro.avsc
@@ -72,6 +72,22 @@
         "type": "long",
         "logicalType": "timestamp-millis"
       }
+    },
+    {
+      "name": "release_id",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
+    },
+    {
+      "name": "service_worker",
+      "type": [
+        "null",
+        "string"
+      ],
+      "default": null
     }
   ]
 }

--- a/schemas/org/openstax/ec/started_session/v1/avro_builder.rb
+++ b/schemas/org/openstax/ec/started_session/v1/avro_builder.rb
@@ -14,4 +14,6 @@ record :started_session_v1 do
   required :referrer, :string
   required :user_agent, :string
   required :occurred_at, :timestamp
+  optional :release_id, :string
+  optional :service_worker, :string
 end

--- a/schemas/org/openstax/ec/started_session/v1/swagger.rb
+++ b/schemas/org/openstax/ec/started_session/v1/swagger.rb
@@ -12,6 +12,15 @@ module Ec::StartedSession::V1
         key :type, :string
         key :description, 'The client generates this UUID and references it for all future events in this session.'
       end
+      property :release_id do
+        key :type, :string
+        key :description, 'The code version of the app.'
+      end
+      property :service_worker do
+        key :type, :string
+        key :description, 'The service worker state'
+        key :enum, ['unsupported', 'inactive', 'active']
+      end
     end
   end
 end


### PR DESCRIPTION
service_worker will get me data i've wanted for a long time about what percentage of users/traffic is on sessions served from a service worker

release_id will help better track folks running old code because of service workers and track the lifecycle of deployments (eg: can generate a report of ongoing events associated release ids and watch as the percentage flips over to the new release)