### PR TITLE
move created_highlight_v2 to its own topic

### DIFF
--- a/config/topics.yml
+++ b/config/topics.yml
@@ -23,6 +23,15 @@ topics: [
     name: 'created_highlight',
     schemas: [
         'org.openstax.ec.created_highlight_v1',
+    ],
+    config: {
+      replication: 3,
+      partitions: 3
+    }
+  },
+  {
+    name: 'created_highlight_2',
+    schemas: [
         'org.openstax.ec.created_highlight_v2'
     ],
     config: {


### PR DESCRIPTION
On further review of the data flow, having both highlights versions in one stream is a bit awkward. Splitting out.
